### PR TITLE
fix: add missing awaits, fix Cypress config

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ module.exports = {
           : [],
         APPLITOOLS_CONCURRENCY: inputs.concurrency,
         PAGES_TO_CHECK: builtPages,
-        CYPRESS_CACHE_FOLDER: 'node_modules',
+        CYPRESS_CACHE_FOLDER: './node_modules/CypressBinary',
       },
       record: false,
     });

--- a/template/visual-diff.json
+++ b/template/visual-diff.json
@@ -1,5 +1,0 @@
-{
-  "integrationFolder": "../netlify-plugin-visual-diff/template/visual-diff/integration",
-  "pluginsFile": "../netlify-plugin-visual-diff/template/visual-diff/plugins",
-  "supportFile": "../netlify-plugin-visual-diff/template/visual-diff/support"
-}

--- a/template/visual-diff/integration/visualdiff.spec.js
+++ b/template/visual-diff/integration/visualdiff.spec.js
@@ -1,8 +1,8 @@
 describe('check the site for visual regressions', () => {
   beforeEach(() => {
     cy.eyesOpen({
-      appName: process.env.SITE_NAME || 'localhost-test',
-      batchName: process.env.SITE_NAME || 'localhost-test',
+      appName: Cypress.env('SITE_NAME'),
+      batchName: Cypress.env('SITE_NAME'),
       browser: JSON.parse(Cypress.env('APPLITOOLS_BROWSERS')),
       failBuildOnDiff: Boolean(Cypress.env('APPLITOOLS_FAIL_BUILD_ON_DIFF')),
       serverUrl: Cypress.env('APPLITOOLS_SERVER_URL'),

--- a/template/visual-diff/visual-diff.json
+++ b/template/visual-diff/visual-diff.json
@@ -1,0 +1,5 @@
+{
+  "integrationFolder": "visual-diff/integration",
+  "pluginsFile": "visual-diff/plugins",
+  "supportFile": "visual-diff/support"
+}


### PR DESCRIPTION
This PR fixes several issues with the plugin (I'll comment on each specific issue).
You can see a successful deploy here:
https://app.netlify.com/sites/erez-applitools-test/deploys/60c62a109e716bf870257240
based on this branch:
https://github.com/erezrokah/test-netlify-applitools/blob/78b8db93119f3ae384c44d4c6fe84725e414ebf3/package.json#L21

It should allow the plugin to work as long as users install it via `npm i -D netlify-plugin-visual-diff`.

I'll submit another PR to make it work when users install it from the UI plugin's directory.

> It doesn't work when installing via the UI since `'@applitools/eyes-cypress'` is a dependency of the plugin and not the site so the following line will fail:
https://github.com/applitools/netlify-plugin-visual-diff/blob/bdafe751c7d0e1653a65463de1615faa92027a95/template/visual-diff/plugins/index.js#L3 since Cypress is executed from the context of the site.